### PR TITLE
Build Docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,22 @@ install:
   - go get github.com/golang/lint/golint
   - go get github.com/pierrre/gotestcover
   - go get -t $(go list ./... | grep -v /vendor/)
+  - git clone https://github.com/docker-library/official-images.git ~/official-images
 
 script:
   # - go vet -x ./...
   - gotestcover -coverprofile="cover.out" -race -covermode="count" $(go list ./... | grep -v /vendor/)
   - goveralls -coverprofile="cover.out"
+  # Test dockerfiles
+  - cd cli/hydra-host
+  - docker build -t "hydra-host" "."
+  - ~/official-images/test/run.sh "hydra-host"
+  - cd ../hydra-signin
+  - docker build -t "hydra-signin" "."
+  - ~/official-images/test/run.sh "hydra-signin"
+  - cd ../hydra-signup
+  - docker build -t "hydra-signup" "."
+  - ~/official-images/test/run.sh "hydra-sigup"
+
+after_script:
+  - docker images

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Join our [mailinglist](http://eepurl.com/bKT3N9) to stay on top of new developme
 - [HTTP/2 RESTful API](#http2-restful-api)
 - [Run hydra-host](#run-hydra-host)
   - [With vagrant](#with-vagrant)
+  - [With docker](#with-docker)
   - [Set up PostgreSQL locally](#set-up-postgresql-locally)
   - [Run as executable](#run-as-executable)
   - [Run from sourcecode](#run-from-sourcecode)
@@ -134,6 +135,16 @@ You can also always access hydra-host through vagrant:
 vagrant ssh
 hydra-host help
 ```
+
+### With Docker
+
+You'll need [Docker](https://www.docker.com/) installed on your system.
+
+```
+docker run --name hydra-postgres -e POSTGRES_PASSWORD=secret -d postgres
+docker run -d --name hydra-host --link hydra-postgres:postgres -p 9000:9000 oryam/hydra
+```
+The hydra container is now running on the *public* port `9000`. This is probably for testing purpose only.
 
 ### Set up PostgreSQL locally
 

--- a/cli/hydra-host/Dockerfile
+++ b/cli/hydra-host/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.6-onbuild
+
+COPY       docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+CMD        ["app"]
+EXPOSE     443

--- a/cli/hydra-host/docker-entrypoint.sh
+++ b/cli/hydra-host/docker-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# Add hydra-host as command if needed
+if [[ "$1" == -* ]]; then
+	set -- app "$@"
+fi
+
+# Rename hydra url to db url
+if [ -z "$DATABASE_URL" ]; then
+	export DATABASE_URL=$HYDRA_DATABASE_URL
+fi
+
+# Auto generate database url by linked containers
+if [ -z "$DATABASE_URL" ]; then
+	if [ -n "$DB_PORT_5432_TCP_PORT" ]; then
+		export DATABASE_URL="postgres://postgres:$HYDRA_DATABASE_PASSWORD@db:5432/postgres?sslmode=disable"
+	elif [ -n "$DB_PORT_29015_TCP_PORT"]; then
+		export DATABASE_URL="rethinkdb://db:29015"
+	fi
+fi
+
+# Start host
+exec "$@"

--- a/cli/hydra-signin/Dockerfile
+++ b/cli/hydra-signin/Dockerfile
@@ -1,0 +1,4 @@
+FROM golang:1.6-onbuild
+
+CMD        ["app"]
+EXPOSE     3000

--- a/cli/hydra-signup/Dockerfile
+++ b/cli/hydra-signup/Dockerfile
@@ -1,0 +1,4 @@
+FROM golang:1.6-onbuild
+
+CMD        ["app"]
+EXPOSE     3001


### PR DESCRIPTION
PR to close issue #60.

I found a way to create the Dockerfiles within' this repo and added docker stuff, tests and a (very) simple README info.

`hydra-signin` and `hydra-signup` are very simple container which are a little too big with 700MB. But it's because of the base image. When there is an `1.6-alpine-onbuild`, we should switch.

The base image is `golang:1.6-onbuild`. It's the easiest way to build the app. I will test to use alpine as the base image, but this should be the second step.

`hydra-host`: The entrypoint script checks for a linked database container and sets the `DATABASE_URL` automatically. This is a common way I borrowed from example [Word(de)press](https://github.com/docker-library/wordpress/blob/master/fpm/docker-entrypoint.sh). But I can extend this script to a better version with deeper checks. 

At the moment, `hydra-host` fails at docker install command because of a vendoring problem. Please check the error we will see in travis and help me fix it.

Unfortunately, I cannot run the official-images docker test on my Mac because it's only working on a linux system. I will need to upgrade this PR multiple times. So please wait until it's a green build