### PR TITLE
Remove go get of govet in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ go:
   - 1.6
 
 install:
-  - go get golang.org/x/tools/cmd/vet
   - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover


### PR DESCRIPTION
Fix error where vet cmd package cannot be found.
The package seems to be included in go now. No need to download it
anymore.