### PR TITLE
cli: add token validation

### DIFF
--- a/cmd/cli/handler.go
+++ b/cmd/cli/handler.go
@@ -9,6 +9,7 @@ type Handler struct {
 	Connections *ConnectionHandler
 	Policies    *PolicyHandler
 	Keys        *JWKHandler
+	Warden      *WardenHandler
 }
 
 func NewHandler(c *config.Config) *Handler {
@@ -17,5 +18,6 @@ func NewHandler(c *config.Config) *Handler {
 		Connections: newConnectionHandler(c),
 		Policies:    newPolicyHandler(c),
 		Keys:        newJWKHandler(c),
+		Warden:      newWardenHandler(c),
 	}
 }

--- a/cmd/cli/handler_warden.go
+++ b/cmd/cli/handler_warden.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/ory-am/hydra/config"
+	"github.com/ory-am/hydra/pkg"
+	"github.com/ory-am/hydra/warden"
+	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
+)
+
+type WardenHandler struct {
+	Config *config.Config
+	M      *warden.HTTPWarden
+}
+
+func newWardenHandler(c *config.Config) *WardenHandler {
+	return &WardenHandler{
+		Config: c,
+		M:      &warden.HTTPWarden{},
+	}
+}
+
+func (h *WardenHandler) IsAuthorized(cmd *cobra.Command, args []string) {
+	h.M.Client = h.Config.OAuth2Client(cmd)
+	h.M.Endpoint = h.Config.Resolve("/connections")
+
+	if len(args) != 1 {
+		fmt.Print(cmd.UsageString())
+		return
+	}
+
+	scopes, _ := cmd.Flags().GetStringSlice("scopes")
+	if len(scopes) == 0 {
+		scopes = []string{"core"}
+	}
+
+	res, err := h.M.Authorized(context.Background(), args[0], scopes...)
+	pkg.Must(err, "Could not validate token: %s", err)
+
+	out, err := json.MarshalIndent(res, "", "\t")
+	pkg.Must(err, "Could not marshall keys: %s", err)
+
+	fmt.Printf("%s\n", out)
+}

--- a/cmd/server/handler_oauth2_factory.go
+++ b/cmd/server/handler_oauth2_factory.go
@@ -3,6 +3,8 @@ package server
 import (
 	"net/url"
 
+	"time"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/go-errors/errors"
 	"github.com/julienschmidt/httprouter"
@@ -27,7 +29,6 @@ import (
 	"github.com/ory-am/hydra/pkg"
 	"golang.org/x/net/context"
 	r "gopkg.in/dancannon/gorethink.v2"
-	"time"
 )
 
 func injectFositeStore(c *config.Config, clients client.Manager) {
@@ -174,10 +175,10 @@ func newOAuth2Handler(c *config.Config, router *httprouter.Router, km jwk.Manage
 			Hasher: &hash.BCrypt{},
 		},
 		Consent: &oauth2.DefaultConsentStrategy{
-			Issuer:     c.Issuer,
-			KeyManager: km,
+			Issuer:                   c.Issuer,
+			KeyManager:               km,
 			DefaultChallengeLifespan: time.Hour,
-			DefaultIDTokenLifespan: time.Hour * 24,
+			DefaultIDTokenLifespan:   time.Hour * 24,
 		},
 		ConsentURL: *consentURL,
 	}

--- a/cmd/token_validate.go
+++ b/cmd/token_validate.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// validateCmd represents the validate command
+var tokenValidatorCmd = &cobra.Command{
+	Use:   "validate <token>",
+	Short: "Check if an access token is valid.",
+	Run:   cmdHandler.Warden.IsAuthorized,
+}
+
+func init() {
+	tokenCmd.AddCommand(tokenValidatorCmd)
+	tokenValidatorCmd.Flags().StringSlice("scopes", []string{"core"}, "Additionally check if scope was granted")
+}

--- a/oauth2/consent_strategy.go
+++ b/oauth2/consent_strategy.go
@@ -23,9 +23,9 @@ const (
 type DefaultConsentStrategy struct {
 	Issuer string
 
-	DefaultIDTokenLifespan time.Duration
+	DefaultIDTokenLifespan   time.Duration
 	DefaultChallengeLifespan time.Duration
-	KeyManager jwk.Manager
+	KeyManager               jwk.Manager
 }
 
 func (s *DefaultConsentStrategy) ValidateResponse(a fosite.AuthorizeRequester, token string) (claims *Session, err error) {
@@ -86,9 +86,9 @@ func (s *DefaultConsentStrategy) ValidateResponse(a fosite.AuthorizeRequester, t
 func toStringSlice(i interface{}) []string {
 	if r, ok := i.([]string); ok {
 		return r
-	} else 	if r, ok := i.(fosite.Arguments); ok {
+	} else if r, ok := i.(fosite.Arguments); ok {
 		return r
-	} else 	if r, ok := i.([]interface{}); ok {
+	} else if r, ok := i.([]interface{}); ok {
 		ret := make([]string, 0)
 		for _, y := range r {
 			s, ok := y.(string)

--- a/oauth2/consent_test.go
+++ b/oauth2/consent_test.go
@@ -2,8 +2,9 @@ package oauth2
 
 import (
 	"testing"
-	"github.com/stretchr/testify/assert"
+
 	"github.com/ory-am/fosite"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestToStringSlice(t *testing.T) {

--- a/oauth2/oauth2_test.go
+++ b/oauth2/oauth2_test.go
@@ -82,10 +82,10 @@ var handler = &Handler{
 		Hasher: hasher,
 	},
 	Consent: &DefaultConsentStrategy{
-		Issuer:     "https://hydra.localhost",
-		KeyManager: keyManager,
+		Issuer:                   "https://hydra.localhost",
+		KeyManager:               keyManager,
 		DefaultChallengeLifespan: time.Hour,
-		DefaultIDTokenLifespan: time.Hour * 24,
+		DefaultIDTokenLifespan:   time.Hour * 24,
 	},
 }
 

--- a/sdk/client_opts.go
+++ b/sdk/client_opts.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 	"net/url"
 
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 )
 
 // ClusterURL sets Hydra service URL

--- a/sdk/client_opts_test.go
+++ b/sdk/client_opts_test.go
@@ -5,8 +5,9 @@ import (
 	"os"
 	"testing"
 
+	"gopkg.in/yaml.v2"
+
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v1"
 )
 
 func TestClusterURLOption(t *testing.T) {


### PR DESCRIPTION
This PR introduces `hydra token validate <token> --scopes=[a,b]`