### PR TITLE
Add the endpoint to the warden wrapper

### DIFF
--- a/sdk/client.go
+++ b/sdk/client.go
@@ -111,7 +111,8 @@ func Connect(opts ...option) (*Client, error) {
 	}
 
 	c.Warden = &warden.HTTPWarden{
-		Client: c.http,
+		Endpoint: pkg.JoinURL(c.clusterURL, warden.AllowedHandlerPath),
+		Client:   c.http,
 	}
 
 	return c, nil


### PR DESCRIPTION
Fix #137 

Without the endpoint the warden client panics