### PR TITLE
vendor: updated jwt-go to 3.0.0. Also fixed a few go vet issues.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: ebc1878cf8d6949bda749aa41fd3f5272edcdee5e7dcae7ca2bfce4f6af02511
-updated: 2016-08-09T10:22:22.712279877+02:00
+hash: 97095e24cb4498df3f04c5e4f9073476a23c2a002d36649c32a9433db501efb2
+updated: 2016-08-23T14:07:40.9088748+02:00
 imports:
 - name: github.com/asaskevich/govalidator
   version: 7664702784775e51966f0885f5cd27435916517b
@@ -8,11 +8,11 @@ imports:
 - name: github.com/cenk/backoff
   version: cdf48bbc1eb78d1349cbda326a4a037f7ba565c6
 - name: github.com/davecgh/go-spew
-  version: 2df174808ee097f90d259e432cc04442cf60be21
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
 - name: github.com/dgrijalva/jwt-go
-  version: 268038b363c7a8d7306b8e35bf77a1fde4b0c402
+  version: d2709f9f1f31ebcda9651b03077758c1f3a0018c
 - name: github.com/fsnotify/fsnotify
   version: a8a77c9133d2d6fd8334f3260d06f60e8d80a5fb
 - name: github.com/go-errors/errors
@@ -28,10 +28,10 @@ imports:
   subpackages:
   - hcl/ast
   - hcl/parser
-  - hcl/token
-  - json/parser
   - hcl/scanner
   - hcl/strconv
+  - hcl/token
+  - json/parser
   - json/scanner
   - json/token
 - name: github.com/inconshreveable/mousetrap
@@ -53,21 +53,21 @@ imports:
 - name: github.com/ory-am/common
   version: d93c852f2d09c219fd058756caf67bbdf8cf4be4
   subpackages:
-  - pkg
-  - rand/sequence
   - compiler
   - env
+  - pkg
+  - rand/sequence
 - name: github.com/ory-am/fosite
-  version: 66b53a903c03950ac5180dc30c3f69e477344205
+  version: 76ef7ea8f51735d63476cd91e1f9a9f367d544cb
   subpackages:
   - compose
   - fosite-example/pkg
   - handler/oauth2
   - handler/openid
   - hash
+  - rand
   - token/hmac
   - token/jwt
-  - rand
 - name: github.com/ory-am/ladon
   version: 67845728bf072d2b3f050cb415ece9a54ec6a546
 - name: github.com/parnurzeal/gorequest
@@ -75,13 +75,13 @@ imports:
 - name: github.com/pborman/uuid
   version: a97ce2ca70fa5a848076093f05e639a89ca34d06
 - name: github.com/pkg/errors
-  version: 01fa4104b9c248c8945d14d9f128454d5b28d595
+  version: 17b591df37844cde689f4d5813e5cea0927d8dd2
 - name: github.com/pkg/profile
   version: 1c16f117a3ab788fdf0e334e623b8bccf5679866
 - name: github.com/pkg/sftp
   version: a71e8f580e3b622ebff585309160b1cc549ef4d2
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
 - name: github.com/Sirupsen/logrus
@@ -98,9 +98,9 @@ imports:
 - name: github.com/spf13/jwalterweatherman
   version: 33c24e77fb80341fe7130ee7c594256ff08ccc46
 - name: github.com/spf13/pflag
-  version: f676131e2660dc8cd88de99f7486d34aa8172635
+  version: 6454a84b6da0ea8b628d5d8a26759f62c6c161b4
 - name: github.com/spf13/viper
-  version: 346299ea79e446ebdddb834371ceba2e5926b732
+  version: 654fc7bb54d0c138ef80405ff577391f79c0c32d
 - name: github.com/square/go-jose
   version: a3927f83df1b1516f9e9dec71839c93e6bcf1db0
   subpackages:
@@ -118,14 +118,14 @@ imports:
   version: e0d166c33c321d0ff863f459a5882096e334f508
   subpackages:
   - bcrypt
-  - pbkdf2
   - blowfish
-  - ssh
   - curve25519
   - ed25519
   - ed25519/internal/edwards25519
+  - pbkdf2
+  - ssh
 - name: golang.org/x/net
-  version: 075e191f18186a8ff2becaf64478e30f4545cdad
+  version: f315505cf3349909cdf013ea56690da34e96a451
   subpackages:
   - context
   - publicsuffix
@@ -146,13 +146,13 @@ imports:
 - name: google.golang.org/appengine
   version: b4728023490a62e70ba739ff62aa65ffcca84210
   subpackages:
-  - urlfetch
   - internal
-  - internal/urlfetch
   - internal/base
   - internal/datastore
   - internal/log
   - internal/remote_api
+  - internal/urlfetch
+  - urlfetch
 - name: gopkg.in/dancannon/gorethink.v2
   version: 27d3045458910e2fc56025a0b52caaaa96414a26
   subpackages:
@@ -167,7 +167,7 @@ imports:
   - cipher
   - json
 - name: gopkg.in/tylerb/graceful.v1
-  version: c838c13b2beeea4f4f54496da96a3a6ae567c37a
+  version: 842f31108f8d3512ce3176d00bf1a32db1d5e3af
 - name: gopkg.in/yaml.v2
   version: e4d366fc3c7938e2958e662b4258c7a89e1f0e3e
 testImports:

--- a/glide.yaml
+++ b/glide.yaml
@@ -15,8 +15,10 @@ import:
   subpackages:
   - pkg
   - rand/sequence
+- package: github.com/dgrijalva/jwt-go
+  version: ~3.0.0
 - package: github.com/ory-am/fosite
-  version: ~0.2.3
+  version: 76ef7ea8f51735d63476cd91e1f9a9f367d544cb #should be changed to a sem-ver
   subpackages:
   - compose
   - fosite-example/pkg
@@ -54,8 +56,6 @@ import:
 - package: golang.org/x/oauth2
   subpackages:
   - clientcredentials
-- package: github.com/dgrijalva/jwt-go
-  version: ~2.7.0
 - package: gopkg.in/tylerb/graceful.v1
   version: ~1.2.11
 - package: gopkg.in/yaml.v2

--- a/oauth2/consent_strategy.go
+++ b/oauth2/consent_strategy.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"crypto/rsa"
+
 	"github.com/dgrijalva/jwt-go"
 
 	"github.com/go-errors/errors"
@@ -46,32 +47,34 @@ func (s *DefaultConsentStrategy) ValidateResponse(a fosite.AuthorizeRequester, t
 		return rsaKey, nil
 	})
 
-	if err != nil {
+	// make sure to use MapClaims since that is the default..
+	jwtClaims, ok := t.Claims.(jwt.MapClaims)
+	if err != nil || !ok {
 		return nil, errors.Errorf("Couldn't parse token: %v", err)
 	} else if !t.Valid {
 		return nil, errors.Errorf("Token is invalid")
 	}
 
-	if time.Now().After(ejwt.ToTime(t.Claims["exp"])) {
+	if time.Now().After(ejwt.ToTime(jwtClaims["exp"])) {
 		return nil, errors.Errorf("Token expired")
 	}
 
-	if ejwt.ToString(t.Claims["aud"]) != a.GetClient().GetID() {
+	if ejwt.ToString(jwtClaims["aud"]) != a.GetClient().GetID() {
 		return nil, errors.Errorf("Audience mismatch")
 	}
 
-	subject := ejwt.ToString(t.Claims["sub"])
-	scopes := toStringSlice(t.Claims["scp"])
+	subject := ejwt.ToString(jwtClaims["sub"])
+	scopes := toStringSlice(jwtClaims["scp"])
 	for _, scope := range scopes {
 		a.GrantScope(scope)
 	}
 
 	var idExt map[string]interface{}
 	var atExt map[string]interface{}
-	if ext, ok := t.Claims["id_ext"].(map[string]interface{}); ok {
+	if ext, ok := jwtClaims["id_ext"].(map[string]interface{}); ok {
 		idExt = ext
 	}
-	if ext, ok := t.Claims["at_ext"].(map[string]interface{}); ok {
+	if ext, ok := jwtClaims["at_ext"].(map[string]interface{}); ok {
 		atExt = ext
 	}
 
@@ -107,14 +110,13 @@ func toStringSlice(i interface{}) []string {
 			}
 		}
 		return ret
-	} else {
-		return []string{}
 	}
+	return []string{}
 }
 
 func (s *DefaultConsentStrategy) IssueChallenge(authorizeRequest fosite.AuthorizeRequester, redirectURL string) (string, error) {
 	token := jwt.New(jwt.SigningMethodRS256)
-	token.Claims = map[string]interface{}{
+	token.Claims = jwt.MapClaims{
 		"jti":   uuid.New(),
 		"scp":   authorizeRequest.GetRequestedScopes(),
 		"aud":   authorizeRequest.GetClient().GetID(),

--- a/oauth2/introspector_test.go
+++ b/oauth2/introspector_test.go
@@ -49,7 +49,7 @@ var localWarden = &warden.LocalWarden{
 	OAuth2: &fosite.Fosite{
 		Store: fositeStore,
 		TokenValidators: fosite.TokenValidators{
-			0: &foauth2.CoreValidator{
+			&foauth2.CoreValidator{
 				CoreStrategy:  pkg.HMACStrategy,
 				CoreStorage:   fositeStore,
 				ScopeStrategy: fosite.HierarchicScopeStrategy,
@@ -78,21 +78,21 @@ func init() {
 	ts = httptest.NewServer(r)
 
 	ar := fosite.NewAccessRequest(oauth2.NewSession("alice"))
-	ar.GrantedScopes = fosite.Arguments{0: "core"}
+	ar.GrantedScopes = fosite.Arguments{"core"}
 	ar.RequestedAt = now
 	ar.Client = &fosite.DefaultClient{ID: "siri"}
 	ar.Session.(*oauth2.Session).Extra = map[string]interface{}{"foo": "bar"}
 	fositeStore.CreateAccessTokenSession(nil, tokens[0][0], ar)
 
 	ar2 := fosite.NewAccessRequest(oauth2.NewSession("siri"))
-	ar2.GrantedScopes = fosite.Arguments{0: "core"}
+	ar2.GrantedScopes = fosite.Arguments{"core"}
 	ar2.RequestedAt = now
 	ar2.Session.(*oauth2.Session).Extra = map[string]interface{}{"foo": "bar"}
 	ar2.Client = &fosite.DefaultClient{ID: "siri"}
 	fositeStore.CreateAccessTokenSession(nil, tokens[1][0], ar2)
 
 	ar3 := fosite.NewAccessRequest(oauth2.NewSession("siri"))
-	ar3.GrantedScopes = fosite.Arguments{0: "core"}
+	ar3.GrantedScopes = fosite.Arguments{"core"}
 	ar3.RequestedAt = now
 	ar2.Session.(*oauth2.Session).Extra = map[string]interface{}{"foo": "bar"}
 	ar3.Client = &fosite.DefaultClient{ID: "doesnt-exist"}

--- a/oauth2/oauth2_auth_code_test.go
+++ b/oauth2/oauth2_auth_code_test.go
@@ -34,6 +34,10 @@ func TestAuthCode(t *testing.T) {
 		pkg.RequireError(t, false, err)
 		require.True(t, tok.Valid)
 
+		jwtClaims, ok := tok.Claims.(jwt.MapClaims)
+		require.True(t, ok)
+		require.NotEmpty(t, jwtClaims)
+
 		consent, err := signConsentToken(map[string]interface{}{
 			"jti": uuid.New(),
 			"exp": time.Now().Add(time.Hour).Unix(),
@@ -43,7 +47,7 @@ func TestAuthCode(t *testing.T) {
 		})
 		pkg.RequireError(t, false, err)
 
-		http.Redirect(w, r, ejwt.ToString(tok.Claims["redir"])+"&consent="+consent, http.StatusFound)
+		http.Redirect(w, r, ejwt.ToString(jwtClaims["redir"])+"&consent="+consent, http.StatusFound)
 		validConsent = true
 	})
 

--- a/oauth2/oauth2_test.go
+++ b/oauth2/oauth2_test.go
@@ -121,7 +121,7 @@ func init() {
 	}
 }
 
-func signConsentToken(claims map[string]interface{}) (string, error) {
+func signConsentToken(claims jwt.MapClaims) (string, error) {
 	token := jwt.New(jwt.SigningMethodRS256)
 	token.Claims = claims
 


### PR DESCRIPTION
This is in reply to #229.

**WIP:** This uses the current HEAD ref in .glide for Fosite. This MUST be changed to a semantic version of Fosite prior to accepting this PR.

_**NOTE:** Untested_