### PR TITLE
warden: firewal.Audience overridden with requesting clients subject

### DIFF
--- a/warden/handler.go
+++ b/warden/handler.go
@@ -68,7 +68,7 @@ func (h *WardenHandler) SetRoutes(r *httprouter.Router) {
 
 func (h *WardenHandler) TokenValid(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	ctx := herodot.NewContext()
-	clientCtx, err := h.Warden.TokenAllowed(ctx, h.Warden.TokenFromRequest(r), &ladon.Request{
+	_, err := h.Warden.TokenAllowed(ctx, h.Warden.TokenFromRequest(r), &ladon.Request{
 		Resource: "rn:hydra:warden:token:valid",
 		Action:   "decide",
 	}, "hydra.warden")
@@ -90,7 +90,6 @@ func (h *WardenHandler) TokenValid(w http.ResponseWriter, r *http.Request, _ htt
 		return
 	}
 
-	authContext.Audience = clientCtx.Subject
 	h.H.Write(ctx, w, r, struct {
 		*firewall.Context
 		Valid bool `json:"valid"`
@@ -129,7 +128,7 @@ func (h *WardenHandler) Allowed(w http.ResponseWriter, r *http.Request, _ httpro
 
 func (h *WardenHandler) TokenAllowed(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	ctx := herodot.NewContext()
-	clientCtx, err := h.Warden.TokenAllowed(ctx, h.Warden.TokenFromRequest(r), &ladon.Request{
+	_, err := h.Warden.TokenAllowed(ctx, h.Warden.TokenFromRequest(r), &ladon.Request{
 		Resource: "rn:hydra:warden:token:allowed",
 		Action:   "decide",
 	}, "hydra.warden")
@@ -154,7 +153,6 @@ func (h *WardenHandler) TokenAllowed(w http.ResponseWriter, r *http.Request, _ h
 		return
 	}
 
-	authContext.Audience = clientCtx.Subject
 	h.H.Write(ctx, w, r, struct {
 		*firewall.Context
 		Allowed bool `json:"allowed"`

--- a/warden/warden_test.go
+++ b/warden/warden_test.go
@@ -88,7 +88,7 @@ func init() {
 	ar2 := fosite.NewAccessRequest(oauth2.NewSession("siri"))
 	ar2.GrantedScopes = fosite.Arguments{"core", "hydra.warden"}
 	ar2.RequestedAt = now
-	ar2.Client = &fosite.DefaultClient{ID: "siri"}
+	ar2.Client = &fosite.DefaultClient{ID: "bob"}
 	fositeStore.CreateAccessTokenSession(nil, tokens[1][0], ar2)
 
 	ar3 := fosite.NewAccessRequest(oauth2.NewSession("siri"))
@@ -195,6 +195,7 @@ func TestActionAllowed(t *testing.T) {
 				scopes:    []string{"core"},
 				expectErr: false,
 				assert: func(c *firewall.Context) {
+					assert.Equal(t, "siri", c.Audience)
 					assert.Equal(t, "alice", c.Subject)
 					assert.Equal(t, "tests", c.Issuer)
 					assert.Equal(t, now.Add(time.Hour), c.ExpiresAt)
@@ -286,6 +287,7 @@ func TestTokenValid(t *testing.T) {
 				scopes:    []string{"core"},
 				expectErr: false,
 				assert: func(c *firewall.Context) {
+					assert.Equal(t, "bob", c.Audience)
 					assert.Equal(t, "siri", c.Subject)
 					assert.Equal(t, "tests", c.Issuer)
 					assert.Equal(t, now.Add(time.Hour), c.ExpiresAt, "expires at", n)


### PR DESCRIPTION
`firewal.Context.Audience` overridden with requesting clients subject in `TokenAllowed` and `TokenValid`

Fix #237 