### PR TITLE
Fix client SQL manager missing client_name

### DIFF
--- a/client/manager_sql.go
+++ b/client/manager_sql.go
@@ -73,6 +73,7 @@ var sqlParams = []string{
 func sqlDataFromClient(d *Client) *sqlData {
 	return &sqlData{
 		ID:                d.ID,
+		Name:              d.Name,
 		Secret:            d.Secret,
 		RedirectURIs:      strings.Join(d.RedirectURIs, "|"),
 		GrantTypes:        strings.Join(d.GrantTypes, "|"),
@@ -91,6 +92,7 @@ func sqlDataFromClient(d *Client) *sqlData {
 func (d *sqlData) ToClient() *Client {
 	return &Client{
 		ID:                d.ID,
+		Name:              d.Name,
 		Secret:            d.Secret,
 		RedirectURIs:      strings.Split(d.RedirectURIs, "|"),
 		GrantTypes:        strings.Split(d.GrantTypes, "|"),

--- a/client/manager_test.go
+++ b/client/manager_test.go
@@ -283,6 +283,7 @@ func TestCreateGetDeleteClient(t *testing.T) {
 
 			c := &Client{
 				ID:                "1234",
+				Name:              "name",
 				Secret:            "secret",
 				RedirectURIs:      []string{"http://redirect"},
 				TermsOfServiceURI: "foo",
@@ -295,6 +296,7 @@ func TestCreateGetDeleteClient(t *testing.T) {
 
 			err = m.CreateClient(&Client{
 				ID:                "2-1234",
+				Name:              "name",
 				Secret:            "secret",
 				RedirectURIs:      []string{"http://redirect"},
 				TermsOfServiceURI: "foo",
@@ -317,6 +319,7 @@ func TestCreateGetDeleteClient(t *testing.T) {
 
 			err = m.UpdateClient(&Client{
 				ID:                "2-1234",
+				Name:              "name-new",
 				Secret:            "secret-new",
 				TermsOfServiceURI: "bar",
 			})
@@ -331,6 +334,7 @@ func TestCreateGetDeleteClient(t *testing.T) {
 				assert.NotEqual(t, d.GetHashedSecret(), nc.GetHashedSecret(), "%s", k)
 			}
 			assert.Equal(t, "bar", nc.TermsOfServiceURI, "%s", k)
+			assert.Equal(t, "name-new", nc.Name, "%s", k)
 			assert.EqualValues(t, []string{"http://redirect"}, nc.GetRedirectURIs(), "%s", k)
 
 			err = m.DeleteClient("1234")


### PR DESCRIPTION
Found the bug when I couldn't set/update the client name of a client.

Signed-off-by: John Wu <johnwu96822@gmail.com>