### PR TITLE
oauth2/revocation: token revocation fails silently with sql store

### DIFF
--- a/cmd/cli/handler.go
+++ b/cmd/cli/handler.go
@@ -5,17 +5,19 @@ import (
 )
 
 type Handler struct {
-	Clients  *ClientHandler
-	Policies *PolicyHandler
-	Keys     *JWKHandler
-	Warden   *WardenHandler
+	Clients    *ClientHandler
+	Policies   *PolicyHandler
+	Keys       *JWKHandler
+	Warden     *WardenHandler
+	Revocation *RevocationHandler
 }
 
 func NewHandler(c *config.Config) *Handler {
 	return &Handler{
-		Clients:  newClientHandler(c),
-		Policies: newPolicyHandler(c),
-		Keys:     newJWKHandler(c),
-		Warden:   newWardenHandler(c),
+		Clients:    newClientHandler(c),
+		Policies:   newPolicyHandler(c),
+		Keys:       newJWKHandler(c),
+		Warden:     newWardenHandler(c),
+		Revocation: newRevocationHandler(c),
 	}
 }

--- a/cmd/cli/handler_recovation.go
+++ b/cmd/cli/handler_recovation.go
@@ -8,6 +8,8 @@ import (
 	"github.com/ory-am/hydra/pkg"
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2/clientcredentials"
+	"crypto/tls"
+	"net/http"
 )
 
 type RevocationHandler struct {
@@ -23,6 +25,13 @@ func newRevocationHandler(c *config.Config) *RevocationHandler {
 }
 
 func (h *RevocationHandler) RevokeToken(cmd *cobra.Command, args []string) {
+	if ok, _ := cmd.Flags().GetBool("skip-tls-verify"); ok {
+		fmt.Println("Warning: Skipping TLS Certificate Verification.")
+		h.M.Client = &http.Client{Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}}
+	}
+
 	h.M.Endpoint = h.Config.Resolve("/oauth2/revoke")
 	h.M.Config = &clientcredentials.Config{
 		ClientID:     h.Config.ClientID,

--- a/cmd/cli/handler_recovation.go
+++ b/cmd/cli/handler_recovation.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"github.com/ory-am/hydra/config"
+	"github.com/ory-am/hydra/oauth2"
+	"github.com/ory-am/hydra/pkg"
+	"github.com/spf13/cobra"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+type RevocationHandler struct {
+	Config *config.Config
+	M      *oauth2.HTTPRecovator
+}
+
+func newRevocationHandler(c *config.Config) *RevocationHandler {
+	return &RevocationHandler{
+		Config: c,
+		M:      &oauth2.HTTPRecovator{},
+	}
+}
+
+func (h *RevocationHandler) RevokeToken(cmd *cobra.Command, args []string) {
+	h.M.Endpoint = h.Config.Resolve("/oauth2/revoke")
+	h.M.Config = &clientcredentials.Config{
+		ClientID:     h.Config.ClientID,
+		ClientSecret: h.Config.ClientSecret,
+	}
+
+	if len(args) != 1 {
+		fmt.Print(cmd.UsageString())
+		return
+	}
+
+	token := args[0]
+	err := h.M.RevokeToken(context.Background(), args[0])
+	pkg.Must(err, "Could not revoke token: %s", err)
+	fmt.Printf("Revoked token %s", token)
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -42,6 +42,7 @@ func TestExecute(t *testing.T) {
 		{args: []string{"keys", "create", "foo", "-a", "HS256"}},
 		{args: []string{"keys", "get", "foo"}},
 		{args: []string{"keys", "delete", "foo"}},
+		{args: []string{"token", "revoke", "foo"}},
 		{args: []string{"token", "client"}},
 		{args: []string{"token", "user", "--no-open"}, wait: func() bool {
 			time.Sleep(time.Millisecond * 10)

--- a/cmd/server/handler_oauth2_factory.go
+++ b/cmd/server/handler_oauth2_factory.go
@@ -142,9 +142,9 @@ func newOAuth2Handler(c *config.Config, router *httprouter.Router, km jwk.Manage
 			DefaultChallengeLifespan: c.GetChallengeTokenLifespan(),
 			DefaultIDTokenLifespan:   c.GetIDTokenLifespan(),
 		},
-		ConsentURL: *consentURL,
-		H:          &herodot.JSON{},
-		AccessTokenLifespan:c.GetAccessTokenLifespan(),
+		ConsentURL:          *consentURL,
+		H:                   &herodot.JSON{},
+		AccessTokenLifespan: c.GetAccessTokenLifespan(),
 	}
 
 	handler.SetRoutes(router)

--- a/cmd/token_revoke.go
+++ b/cmd/token_revoke.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// validateCmd represents the validate command
+var tokenRevokeCmd = &cobra.Command{
+	Use:   "revoke <token>",
+	Short: "Revoke an access or refresh token",
+	Run:   cmdHandler.Revocation.RevokeToken,
+}
+
+func init() {
+	tokenCmd.AddCommand(tokenRevokeCmd)
+
+}

--- a/cmd/token_validate.go
+++ b/cmd/token_validate.go
@@ -7,7 +7,7 @@ import (
 // validateCmd represents the validate command
 var tokenValidatorCmd = &cobra.Command{
 	Use:   "validate <token>",
-	Short: "Check if an access token is valid.",
+	Short: "Check if an access token is valid",
 	Run:   cmdHandler.Warden.IsAuthorized,
 }
 

--- a/firewall/warden.go
+++ b/firewall/warden.go
@@ -87,7 +87,7 @@ type Firewall interface {
 	// TokenFromRequest returns an access token from the HTTP Authorization header.
 	//
 	//  func anyHttpHandler(w http.ResponseWriter, r *http.Request) {
-	//    ctx, err := firewall.TokenValid(context.Background(), firewall.TokenFromRequest(r), "photos", "files")
+	//    ctx, err := firewall.TokenAllowed(context.Background(), firewall.TokenFromRequest(r), "photos", "files")
 	//    fmt.Sprintf("%s", ctx.Subject)
 	//  }
 	TokenFromRequest(r *http.Request) string

--- a/oauth2/handler_consent_test.go
+++ b/oauth2/handler_consent_test.go
@@ -1,11 +1,11 @@
 package oauth2
 
 import (
-	"net/http/httptest"
-	"net/http"
-	"io/ioutil"
 	"github.com/julienschmidt/httprouter"
 	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 

--- a/oauth2/revocator_http.go
+++ b/oauth2/revocator_http.go
@@ -15,6 +15,7 @@ type HTTPRecovator struct {
 	Config   *clientcredentials.Config
 	Dry      bool
 	Endpoint *url.URL
+	Client *http.Client
 }
 
 func (r *HTTPRecovator) RevokeToken(ctx context.Context, token string) error {
@@ -30,7 +31,10 @@ func (r *HTTPRecovator) RevokeToken(ctx context.Context, token string) error {
 	hreq.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	hreq.Header.Add("Content-Length", strconv.Itoa(len(data.Encode())))
 	hreq.SetBasicAuth(r.Config.ClientID, r.Config.ClientSecret)
-	hres, err := http.DefaultClient.Do(hreq)
+	if r.Client == nil {
+		r.Client = http.DefaultClient
+	}
+	hres, err := r.Client.Do(hreq)
 	if err != nil {
 		return errors.Wrap(err, "")
 	}

--- a/oauth2/revocator_test.go
+++ b/oauth2/revocator_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ory-am/hydra/herodot"
 	"github.com/ory-am/hydra/oauth2"
 	"github.com/ory-am/hydra/pkg"
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/clientcredentials"
 )
@@ -87,6 +88,7 @@ func TestRevoke(t *testing.T) {
 		for _, c := range []struct {
 			token     string
 			expectErr bool
+			assert    func(*testing.T)
 		}{
 			{
 				token:     "invalid",
@@ -95,6 +97,9 @@ func TestRevoke(t *testing.T) {
 			{
 				token:     tokensRecovator[0][1],
 				expectErr: false,
+				assert: func(t *testing.T) {
+					assert.Len(t, fositeStoreRecovator.AccessTokens, 2)
+				},
 			},
 			{
 				token:     tokensRecovator[0][1],
@@ -103,15 +108,24 @@ func TestRevoke(t *testing.T) {
 			{
 				token:     tokensRecovator[2][1],
 				expectErr: false,
+				assert: func(t *testing.T) {
+					assert.Len(t, fositeStoreRecovator.AccessTokens, 1)
+				},
 			},
 			{
 				token:     tokensRecovator[1][1],
 				expectErr: false,
+				assert: func(t *testing.T) {
+					assert.Len(t, fositeStoreRecovator.AccessTokens, 0)
+				},
 			},
 		} {
 			t.Run(fmt.Sprintf("case=%s", k), func(t *testing.T) {
 				err := w.RevokeToken(context.Background(), c.token)
 				pkg.AssertError(t, c.expectErr, err)
+				if c.assert != nil {
+					c.assert(t)
+				}
 			})
 		}
 	}

--- a/oauth2/session.go
+++ b/oauth2/session.go
@@ -1,11 +1,11 @@
 package oauth2
 
 import (
-	"github.com/ory-am/fosite/handler/openid"
-	"github.com/ory-am/fosite/token/jwt"
-	"github.com/ory-am/fosite"
 	"bytes"
 	"encoding/gob"
+	"github.com/ory-am/fosite"
+	"github.com/ory-am/fosite/handler/openid"
+	"github.com/ory-am/fosite/token/jwt"
 )
 
 type Session struct {


### PR DESCRIPTION
An issue with token revocation has been resolved, and I added an hydra token revoke CLI command:

```
$ hydra token client
XxDIiLvQnnB_4LUyMcrgDBMxz-EV4kVWd_HdK7bg0Nw.rQDfXz3-Uc3lPxgB2U-PwsgPhw2P-JwgHaydiPh0cfE

$ hydra token revoke XxDIiLvQnnB_4LUyMcrgDBMxz-EV4kVWd_HdK7bg0Nw.rQDfXz3-Uc3lPxgB2U-PwsgPhw2P-JwgHaydiPh0cfE
Revoked token XxDIiLvQnnB_4LUyMcrgDBMxz-EV4kVWd_HdK7bg0Nw.rQDfXz3-Uc3lPxgB2U-PwsgPhw2P-JwgHaydiPh0cfE

$ hydra token validate XxDIiLvQnnB_4LUyMcrgDBMxz-EV4kVWd_HdK7bg0Nw.rQDfXz3-Uc3lPxgB2U-PwsgPhw2P-JwgHaydiPh0cfE
Could not validate token: Token is malformed, expired or otherwise invalid
```