### PR TITLE
docker: --name should be before the image's name

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ You can use Hydra without a database, but be aware that restarting, scaling
 or stopping the container will **lose all data**:
 
 ```
-$ docker run -d -p 4444:4444 oryam/hydra --name my-hydra
+$ docker run -d --name my-hydra -p 4444:4444 oryam/hydra
 ec91228cb105db315553499c81918258f52cee9636ea2a4821bdb8226872f54b
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -18,7 +18,7 @@ In this minimalistic example, we will use Hydra without a database. Bee aware th
 or stopping the container will **lose all the data**.
 
 ```
-$ docker run -d -p 4444:4444 oryam/hydra --name my-hydra
+$ docker run -d --name my-hydra -p 4444:4444 oryam/hydra
 ec91228cb105db315553499c81918258f52cee9636ea2a4821bdb8226872f54b
 ```
 


### PR DESCRIPTION
> Usage:	docker run [OPTIONS] IMAGE [COMMAND] [ARG...]

Without this commit, the container name is not 'my-hydra'. As `--name` is an option it should be before the image's name.