### PR TITLE
Log fixes

### DIFF
--- a/config/backend_connections.go
+++ b/config/backend_connections.go
@@ -35,7 +35,7 @@ func (c *SQLConnection) GetDatabase() *sqlx.DB {
 
 	var err error
 	if err = pkg.Retry(time.Second*15, time.Minute*2, func() error {
-		logrus.Infof("Connecting with %s", c.URL.String())
+		logrus.Infof("Connecting with %s", c.URL.Scheme+"://*:*@"+c.URL.Host+c.URL.Path+"?"+c.URL.RawQuery)
 		u := c.URL.String()
 		if c.URL.Scheme == "mysql" {
 			u = strings.Replace(u, "mysql://", "", -1)

--- a/docs/faq/log-level.md
+++ b/docs/faq/log-level.md
@@ -3,6 +3,7 @@
 Yes, you can do so by setting the environment variable `LOG_LEVEL=<level>`. There are various levels supported:
 
 * debug
+* info
 * warn
 * error
 * fatal

--- a/main.go
+++ b/main.go
@@ -25,6 +25,9 @@ func main() {
 	case "warn":
 		logrus.SetLevel(logrus.WarnLevel)
 		break
+	case "error":
+		logrus.SetLevel(logrus.ErrorLevel)
+		break
 	case "fatal":
 		logrus.SetLevel(logrus.FatalLevel)
 		break


### PR DESCRIPTION
1. Fix log level missing the "error" level set from LOG_LEVEL
2. Do not display datastore username and password in the log

Signed-off-by: John Wu <johnwu96822@gmail.com>